### PR TITLE
feat: add callbacks onSuccess and onError

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -58,6 +58,7 @@ function sidebar() {
         { text: 'Mutation', link: '/mutation' },
         { text: 'Global Configuration', link: '/global-configuration' },
         { text: 'Data Fetching', link: '/data-fetching' },
+        { text: 'Error Handling', link: '/error-handling' },
         { text: 'Conditional Fetching', link: '/conditional-fetching' },
       ]
     },

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,30 @@
+# Error Handling
+
+If an error is thrown inside [fetcher](./data-fetching), it will be returned as `error` by the composable
+
+```ts
+// ...
+const { data, error } = useSWR('/api/user', fetcher);
+```
+
+The `error` object will be defined if the fetch promise is rejected or `fetcher` contains an syntax error.
+
+## Global Error Report
+
+You can always get the `error` object inside the component reactively. But in case you want to handle the error globally, to notify the UI to show a toast or a snackbar, or report it somewhere such as [Sentry](https://sentry.io/), there's an `onError` event:
+
+```ts
+configureGlobalSWR({
+  onError: (error, key) => {
+    // We can send the error to Sentry,
+
+    if (error.status !== 403 && error.status !== 404) {
+      // or show a notification UI.
+    }
+  }
+})
+```
+
+This is also available in the composable options.
+
+In case that you pass an global `onError` and in a composable inside the same context also pass a `onError` the two of them will be called. First the local one followed by the global

--- a/docs/options.md
+++ b/docs/options.md
@@ -23,3 +23,5 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnReconnect = true` - Automatically revalidate when the browser regains a network connection
 - `revalidateIfStale = true` - Automatically revalidate if there is stale data
 - `dedupingInterval = 2000` - dedupe requests with the same key in this time span in milliseconds
+- `onSuccess(data, key, config)` - callback function when a request finishes successfully
+- `onError(err, key, config)` - callback function when a request returns an error

--- a/lib/composables/swr/index.ts
+++ b/lib/composables/swr/index.ts
@@ -12,6 +12,7 @@ export const useSWR = <Data = any, Error = any>(
   config: SWRComposableConfig = {},
 ) => {
   const { config: contextConfig, mutate } = useSWRConfig();
+  const mergedConfig = mergeConfig(contextConfig.value, config);
 
   const {
     cacheProvider,
@@ -19,7 +20,9 @@ export const useSWR = <Data = any, Error = any>(
     revalidateOnReconnect,
     revalidateIfStale,
     dedupingInterval,
-  } = mergeConfig(contextConfig.value, config);
+    onSuccess,
+    onError,
+  } = mergedConfig;
 
   const { key, args: fetcherArgs } = toRefs(toReactive(computed(() => serializeKey(_key))));
 
@@ -46,8 +49,12 @@ export const useSWR = <Data = any, Error = any>(
 
       data.value = fetcherResponse;
       fetchedIn.value = new Date();
+
+      if (onSuccess) onSuccess(data.value, key.value, mergedConfig);
     } catch (err: any) {
       error.value = err;
+
+      if (onError) onError(err, key.value, mergedConfig);
     } finally {
       isValidating.value = false;
     }

--- a/lib/config/injection-keys.ts
+++ b/lib/config/injection-keys.ts
@@ -3,8 +3,9 @@ import { DeepReadonly, InjectionKey, Ref } from 'vue';
 import { SWRConfig } from '@/types';
 
 /**
+ * Key for provide and get current context configs
  * @internal
  */
 export const globalConfigKey = Symbol('SWR global config key') as InjectionKey<
-  DeepReadonly<Ref<Required<SWRConfig>>>
+  DeepReadonly<Ref<SWRConfig>>
 >;

--- a/lib/config/swr-config.ts
+++ b/lib/config/swr-config.ts
@@ -3,7 +3,7 @@ import { reactive } from 'vue';
 import { SWRConfig } from '@/types';
 import { MapAdapter } from '@/cache';
 
-export const defaultConfig: Required<SWRConfig> = {
+export const defaultConfig: SWRConfig = {
   cacheProvider: reactive(new MapAdapter()),
   revalidateOnFocus: true,
   revalidateOnReconnect: true,

--- a/lib/types/lib.ts
+++ b/lib/types/lib.ts
@@ -32,9 +32,29 @@ export type CacheState = {
 
 export type SWRConfig = {
   cacheProvider?: CacheProvider<CacheState>;
+
+  /**
+   * automatically revalidate when window gets focused
+   * @defaultValue true
+   */
   revalidateOnFocus?: boolean;
+
+  /**
+   * automatically revalidate when the browser regains a network connection (via `navigator.onLine`)
+   * @defaultValue true
+   */
   revalidateOnReconnect?: boolean;
+
+  /**
+   * automatically revalidate even if there is stale data
+   * @defaultValue true
+   */
   revalidateIfStale?: boolean;
+
+  /**
+   * dedupe requests with the same key in this time span in miliseconds
+   * @defaultValue: 2000
+   */
   dedupingInterval?: number;
 };
 

--- a/lib/types/lib.ts
+++ b/lib/types/lib.ts
@@ -60,6 +60,16 @@ export type SWRConfig<Data = any, Err = any> = {
    * @default 2000
    */
   dedupingInterval: number;
+
+  /**
+   * called when a request finishes successfully
+   */
+  onSuccess?: (data: Data, key: string, config: SWRConfig<Data, Err>) => void;
+
+  /**
+   * called when a request returns an error
+   */
+  onError?: (err: Err, key: string, config: SWRConfig<Data, Err>) => void;
 };
 
 export type SWRComposableConfig = Omit<Partial<SWRConfig>, 'cacheProvider'>;

--- a/lib/types/lib.ts
+++ b/lib/types/lib.ts
@@ -31,31 +31,35 @@ export type CacheState = {
 };
 
 export type SWRConfig = {
-  cacheProvider?: CacheProvider<CacheState>;
+  /**
+   * stores the cached values
+   * @default new Map()
+   */
+  cacheProvider: CacheProvider<CacheState>;
 
   /**
    * automatically revalidate when window gets focused
-   * @defaultValue true
+   * @default true
    */
-  revalidateOnFocus?: boolean;
+  revalidateOnFocus: boolean;
 
   /**
    * automatically revalidate when the browser regains a network connection (via `navigator.onLine`)
-   * @defaultValue true
+   * @default true
    */
-  revalidateOnReconnect?: boolean;
+  revalidateOnReconnect: boolean;
 
   /**
    * automatically revalidate even if there is stale data
-   * @defaultValue true
+   * @default true
    */
-  revalidateIfStale?: boolean;
+  revalidateIfStale: boolean;
 
   /**
    * dedupe requests with the same key in this time span in miliseconds
-   * @defaultValue: 2000
+   * @default 2000
    */
-  dedupingInterval?: number;
+  dedupingInterval: number;
 };
 
-export type SWRComposableConfig = Omit<SWRConfig, 'cacheProvider'>;
+export type SWRComposableConfig = Omit<Partial<SWRConfig>, 'cacheProvider'>;

--- a/lib/types/lib.ts
+++ b/lib/types/lib.ts
@@ -30,7 +30,7 @@ export type CacheState = {
   fetchedIn: Ref<Date>;
 };
 
-export type SWRConfig = {
+export type SWRConfig<Data = any, Err = any> = {
   /**
    * stores the cached values
    * @default new Map()

--- a/lib/utils/chain-fn/chain-fn.spec.ts
+++ b/lib/utils/chain-fn/chain-fn.spec.ts
@@ -1,0 +1,21 @@
+import { chainFns } from '.';
+
+describe('chainFn', () => {
+  it('should call all cahined functions', () => {
+    const functions = [vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn()];
+    const chainedFn = chainFns(...functions);
+
+    chainedFn();
+
+    functions.forEach((fn) => expect(fn).toHaveBeenCalledOnce());
+  });
+
+  it('should call all chained functions with the same arguments', () => {
+    const functions = [vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn()];
+    const chainedFn = chainFns(...functions);
+
+    chainedFn('arg1', 'arg2', 3);
+
+    functions.forEach((fn) => expect(fn).toHaveBeenCalledWith('arg1', 'arg2', 3));
+  });
+});

--- a/lib/utils/chain-fn/index.ts
+++ b/lib/utils/chain-fn/index.ts
@@ -1,0 +1,8 @@
+import { AnyFunction } from '@/types';
+
+export const chainFns = <F extends (AnyFunction | undefined)[]>(...fns: F) => {
+  const validFns = fns.filter(<T>(maybeFn: T | undefined): maybeFn is T => !!maybeFn);
+
+  return (...params: Parameters<Exclude<F[number], undefined>>) =>
+    validFns.forEach((fn) => fn(...params));
+};

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,3 +2,4 @@ export * from './check-types';
 export * from './hash';
 export * from './serialize-key';
 export * from './merge-config';
+export * from './chain-fn';

--- a/lib/utils/merge-config/index.ts
+++ b/lib/utils/merge-config/index.ts
@@ -1,9 +1,19 @@
 import { SWRConfig } from '@/types';
 
+import { chainFns } from '../chain-fn';
+
 export const mergeConfig = <T extends Partial<SWRConfig>, D extends Partial<SWRConfig>>(
   fallbackConfig: T,
   config: D,
-) => ({
-  ...fallbackConfig,
-  ...config,
-});
+) => {
+  const onSuccess = [config.onSuccess, fallbackConfig.onSuccess].filter(Boolean);
+  const onError = [config.onError, fallbackConfig.onError].filter(Boolean);
+
+  return {
+    ...fallbackConfig,
+    ...config,
+
+    onSuccess: onSuccess.length > 0 ? chainFns(...onSuccess) : undefined,
+    onError: onError.length > 0 ? chainFns(...onError) : undefined,
+  };
+};

--- a/lib/utils/merge-config/merge-config.spec.ts
+++ b/lib/utils/merge-config/merge-config.spec.ts
@@ -20,4 +20,46 @@ describe('mergeConfig', () => {
   ])('should merge two configs: %s', (obj1, obj2, expectedResult) => {
     expect(mergeConfig(obj1, obj2)).toEqual(expectedResult);
   });
+
+  it('should also merge callbacks', () => {
+    const globalConfig = Object.freeze({
+      onError: vi.fn(),
+      onSuccess: vi.fn(),
+    });
+
+    const localConfig = Object.freeze({
+      onError: vi.fn(),
+      onSuccess: vi.fn(),
+    });
+
+    const { onError, onSuccess } = mergeConfig(globalConfig, localConfig);
+
+    onError();
+    onSuccess();
+
+    expect(globalConfig.onSuccess).toHaveBeenCalledOnce();
+    expect(globalConfig.onError).toHaveBeenCalledOnce();
+    expect(localConfig.onSuccess).toHaveBeenCalledOnce();
+    expect(localConfig.onError).toHaveBeenCalledOnce();
+  });
+
+  it('should not throw when one of the callbacks is missing', () => {
+    const globalConfig = Object.freeze({ onSuccess: vi.fn() });
+    const localConfig = Object.freeze({ onError: vi.fn() });
+
+    const { onError, onSuccess } = mergeConfig(globalConfig, localConfig);
+
+    onError();
+    onSuccess();
+
+    expect(globalConfig.onSuccess).toHaveBeenCalledOnce();
+    expect(localConfig.onError).toHaveBeenCalledOnce();
+  });
+
+  it('should return undefined when callback is missing in either configs', () => {
+    const { onError, onSuccess } = mergeConfig({}, {});
+
+    expect(onError).toBeUndefined();
+    expect(onSuccess).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Add two more options globals and per hook

- `onSuccess(data, key, config)` - called when the fetcher call successed
- `onError(err, key, config)` - called when the fetcher throws

When pass an global one and one in the hook, both will be called