### PR TITLE
feat: add `fallbackData` option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -23,5 +23,6 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnReconnect = true` - Automatically revalidate when the browser regains a network connection
 - `revalidateIfStale = true` - Automatically revalidate if there is stale data
 - `dedupingInterval = 2000` - dedupe requests with the same key in this time span in milliseconds
+- `fallbackData` - initial data to be returned (note: This is per-composable, but also be passed in global config)
 - `onSuccess(data, key, config)` - callback function when a request finishes successfully
 - `onError(err, key, config)` - callback function when a request returns an error

--- a/lib/composables/swr/index.ts
+++ b/lib/composables/swr/index.ts
@@ -20,6 +20,7 @@ export const useSWR = <Data = any, Error = any>(
     revalidateOnReconnect,
     revalidateIfStale,
     dedupingInterval,
+    fallbackData,
     onSuccess,
     onError,
   } = mergedConfig;
@@ -31,7 +32,7 @@ export const useSWR = <Data = any, Error = any>(
 
   const error = valueInCache.value ? toRef(valueInCache.value, 'error') : ref<Error>();
   const isValidating = valueInCache.value ? toRef(valueInCache.value, 'isValidating') : ref(true);
-  const data = valueInCache.value ? toRef(valueInCache.value, 'data') : ref();
+  const data = valueInCache.value ? toRef(valueInCache.value, 'data') : ref(fallbackData);
   const fetchedIn = valueInCache.value ? toRef(valueInCache.value, 'fetchedIn') : ref(new Date());
 
   const fetchData = async () => {

--- a/lib/composables/swr/swr.spec.ts
+++ b/lib/composables/swr/swr.spec.ts
@@ -531,4 +531,41 @@ describe('useSWR', () => {
       expect.objectContaining(mergedConfig),
     );
   });
+
+  it('should return fallbackData as initial value', () => {
+    const fallbackData = 'fallback';
+
+    const { data } = useInjectedSetup(
+      () => configureGlobalSWR({ cacheProvider }),
+      () => useSWR(defaultKey, defaultFetcher, { fallbackData }),
+    );
+
+    expect(data.value).toBe(fallbackData);
+  });
+
+  it('should return global fallbackData as initial value', () => {
+    const fallbackData = 'fallback';
+
+    const { data } = useInjectedSetup(
+      () => configureGlobalSWR({ cacheProvider, fallbackData }),
+      () => useSWR(defaultKey, defaultFetcher),
+    );
+
+    expect(data.value).toBe(fallbackData);
+  });
+
+  it('should return stale data fallbackData and stale data are present', async () => {
+    const fallbackData = 'fallback';
+    const cahedData = 'cached value';
+
+    setDataToCache(defaultKey, { data: cahedData });
+
+    const { data } = useInjectedSetup(
+      () => configureGlobalSWR({ cacheProvider, fallbackData }),
+      () => useSWR(defaultKey, defaultFetcher),
+    );
+
+    await flushPromises();
+    expect(data.value).toBe(cahedData);
+  });
 });

--- a/lib/types/lib.ts
+++ b/lib/types/lib.ts
@@ -62,6 +62,11 @@ export type SWRConfig<Data = any, Err = any> = {
   dedupingInterval: number;
 
   /**
+   * initial data to be returned (note: ***This is per-composable***)
+   */
+  fallbackData?: Data;
+
+  /**
    * called when a request finishes successfully
    */
   onSuccess?: (data: Data, key: string, config: SWRConfig<Data, Err>) => void;


### PR DESCRIPTION
Add option `fallbackData`.

The value passed to this option will be returned to the `data` from the composable while the composable not finish its request. Also can be used for prefetched data